### PR TITLE
Refactor Sample to Trigger MyPage Disposal

### DIFF
--- a/CommunityMauiMediaElement/App.xaml.cs
+++ b/CommunityMauiMediaElement/App.xaml.cs
@@ -2,11 +2,11 @@
 {
     public partial class App : Application
     {
-        public App()
+        public App(AppShell appShell)
         {
             InitializeComponent();
 
-            MainPage = new AppShell();
+            MainPage = appShell;
         }
     }
 }

--- a/CommunityMauiMediaElement/AppShell.xaml
+++ b/CommunityMauiMediaElement/AppShell.xaml
@@ -7,9 +7,4 @@
     Shell.FlyoutBehavior="Disabled"
     Title="CommunityMauiMediaElement">
 
-    <ShellContent
-        Title="Home"
-        ContentTemplate="{DataTemplate local:MainPage}"
-        Route="MainPage" />
-
 </Shell>

--- a/CommunityMauiMediaElement/AppShell.xaml.cs
+++ b/CommunityMauiMediaElement/AppShell.xaml.cs
@@ -2,14 +2,37 @@
 
 namespace CommunityMauiMediaElement
 {
-    public partial class AppShell : Shell
-    {
-        public AppShell()
-        {
-            InitializeComponent();
+	public partial class AppShell : Shell
+	{
+		public AppShell(MainPage mainPage)
+		{
+			InitializeComponent();
+			
+			Items.Add(mainPage);
 
-            Routing.RegisterRoute(nameof(MyPage), typeof(MyPage));
-            Routing.RegisterRoute(nameof(MyThirdPage), typeof(MyThirdPage));
-        }
-    }
+			Routing.RegisterRoute(GetRoute<MainPage>(), typeof(MainPage));
+			Routing.RegisterRoute(GetRoute<MyPage>(), typeof(MyPage));
+			Routing.RegisterRoute(GetRoute<MyThirdPage>(), typeof(MyThirdPage));
+		}
+
+		public static string GetRoute<T>() where T : ContentPage
+		{
+			if (typeof(T) == typeof(MainPage))
+			{
+				return $"//{nameof(MainPage)}";
+			}
+
+			if (typeof(T) == typeof(MyPage))
+			{
+				return $"//{nameof(MainPage)}/{nameof(MyThirdPage)}/{nameof(MyPage)}";
+			}
+
+			if (typeof(T) == typeof(MyThirdPage))
+			{
+				return $"//{nameof(MainPage)}/{nameof(MyThirdPage)}/";
+			}
+
+			throw new NotSupportedException();
+		}
+	}
 }

--- a/CommunityMauiMediaElement/MainPage.xaml.cs
+++ b/CommunityMauiMediaElement/MainPage.xaml.cs
@@ -3,26 +3,33 @@ using CommunityMauiMediaElement.Views;
 
 namespace CommunityMauiMediaElement
 {
-    public partial class MainPage : ContentPage
-    {
-        public MainPage()
-        {
-            InitializeComponent();
+	public partial class MainPage : ContentPage
+	{
+		public MainPage()
+		{
+			InitializeComponent();
+		}
+		
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+			
+			Trace.WriteLine("Pages in NavigationStack:");
 
-            Loaded += OnLoaded;
-        }
+			foreach (var page in Navigation.NavigationStack)
+			{
+				Trace.WriteLine($"\t{page?.GetType().FullName ?? "null"}");
+			}
+			
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			var totalMemory = GC.GetTotalMemory(true);
+			Trace.WriteLine($"Memory: {totalMemory}");
+		}
 
-        private void OnLoaded(object? sender, EventArgs e)
-        {
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            var totalMemory = GC.GetTotalMemory(true);
-            Debug.WriteLine($"Memory: {totalMemory}");
-        }
-
-        private async void Button_OnClicked(object? sender, EventArgs e)
-        {
-            await Shell.Current.GoToAsync(nameof(MyPage));
-        }
-    }
+		private async void Button_OnClicked(object? sender, EventArgs e)
+		{
+			await Shell.Current.GoToAsync(AppShell.GetRoute<MyThirdPage>());
+		}
+	}
 }

--- a/CommunityMauiMediaElement/MauiProgram.cs
+++ b/CommunityMauiMediaElement/MauiProgram.cs
@@ -23,6 +23,10 @@ namespace CommunityMauiMediaElement
     		builder.Logging.AddDebug();
 #endif
 
+            builder.Services.AddSingleton<AppShell>();
+            builder.Services.AddSingleton<IFileSystem>(FileSystem.Current);
+            
+            builder.Services.AddTransient<MainPage>();
             builder.Services.AddTransient<MyPage>();
             builder.Services.AddTransient<MyViewModel>();
 

--- a/CommunityMauiMediaElement/ViewModels/MyViewModel.cs
+++ b/CommunityMauiMediaElement/ViewModels/MyViewModel.cs
@@ -1,20 +1,6 @@
 ﻿namespace CommunityMauiMediaElement.ViewModels;
 
-public class MyViewModel
+public class MyViewModel(IFileSystem fileSystem)
 {
-    public string FilePath => Path.Combine(BaseFolderPath, "Sister.m4a");
-
-    private string BaseFolderPath
-    {
-        get
-        {
-#if IOS || MACCATALYST
-            return Foundation.NSBundle.MainBundle.BundlePath;
-#elif WINDOWS10_0_17763_0_OR_GREATER
-            return AppDomain.CurrentDomain.BaseDirectory;
-#else
-            throw new NotImplementedException();
-#endif
-        }
-    }
+    public string FilePath => Path.Combine(fileSystem.AppDataDirectory, "Sister.m4a");
 }

--- a/CommunityMauiMediaElement/Views/MyPage.xaml.cs
+++ b/CommunityMauiMediaElement/Views/MyPage.xaml.cs
@@ -5,40 +5,41 @@ namespace CommunityMauiMediaElement.Views;
 
 public partial class MyPage : ContentPage
 {
-    public MyPage(MyViewModel viewModel)
+    public MyPage()
     {
         InitializeComponent();
-        BindingContext = viewModel;
 
+        Trace.WriteLine($"{this.GetType().FullName} Initialized");
+        
         Unloaded += OnUnloaded;
+    }
+    
+    ~MyPage()
+    {
+        Trace.WriteLine($"{this.GetType().FullName} Disposed");
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+		
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
     }
 
     private void OnUnloaded(object? sender, EventArgs e)
     {
         Debug.WriteLine("OnUnloaded() called");
         MyMediaElement.Pause();
-    }
-
-    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
-    {
-        base.OnHandlerChanging(args);
-
-        if (args.NewHandler != null)
-        {
-            return;
-        }
-
         MyMediaElement.Handler?.DisconnectHandler();
         Debug.WriteLine("OnHandlerChanging.DisconnectHandler() called");
+        
+        
+        Unloaded -= OnUnloaded;
     }
 
     private async void Button_OnClicked(object? sender, EventArgs e)
     {
-        await Shell.Current.GoToAsync(nameof(MyThirdPage));
-    }
-
-    ~MyPage()
-    {
-        Debug.WriteLine("~MyPage() called");
+        await Shell.Current.GoToAsync(AppShell.GetRoute<MyThirdPage>());
     }
 }

--- a/CommunityMauiMediaElement/Views/MyThirdPage.xaml
+++ b/CommunityMauiMediaElement/Views/MyThirdPage.xaml
@@ -8,6 +8,8 @@
         Spacing="30">
 
         <Label Text="Page after MediaElement > navigate back..." />
+        <Button Text="2) Go to next page > Unloaded gets called"
+                Clicked="Button_OnClicked" />
 
     </VerticalStackLayout>
 </ContentPage>

--- a/CommunityMauiMediaElement/Views/MyThirdPage.xaml.cs
+++ b/CommunityMauiMediaElement/Views/MyThirdPage.xaml.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 namespace CommunityMauiMediaElement.Views;
 
 public partial class MyThirdPage : ContentPage
@@ -5,5 +6,24 @@ public partial class MyThirdPage : ContentPage
 	public MyThirdPage()
 	{
 		InitializeComponent();
+		Trace.WriteLine($"{this.GetType().FullName} Initialized");
+	}
+
+	protected override void OnAppearing()
+	{
+		base.OnAppearing();
+		
+		GC.Collect();
+		GC.WaitForPendingFinalizers();
+	}
+
+	~MyThirdPage()
+	{
+		Trace.WriteLine($"{this.GetType().FullName} Disposed");
+	}
+	
+	private async void Button_OnClicked(object? sender, EventArgs e)
+	{
+		await Shell.Current.GoToAsync(AppShell.GetRoute<MyPage>());
 	}
 }


### PR DESCRIPTION
Hey @marco-skizza! 

After some refactoring, I was able to trigger the finalizer in `MyPage` on both iOS + Android, despite it using the MediaElement.

This fork contains the updated sample. To trigger the disposal of `MyPage`, continue to click the Button on each page to navigate back-and-forth between `MyPage` and `MyThirdPage`. With the debugger attached and a breakpoint in `~MyPage()`, you will see the page does get disposed.

<img width="1728" alt="image" src="https://github.com/marco-skizza/CommunityMauiMediaElement/assets/13558917/982f6530-5937-4f5a-92b7-c77d7c67d6e8">
